### PR TITLE
Update WorkshopStack.yaml

### DIFF
--- a/deployment/WorkshopStack.yaml
+++ b/deployment/WorkshopStack.yaml
@@ -234,7 +234,7 @@ Resources:
           PROJECT_NAME:
             Ref: InstallWorkshopStack
       Handler: index.lambda_handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 900
       ReservedConcurrentExecutions: 1
     DependsOn:


### PR DESCRIPTION
Python 3.11 is unsupported now.

*Issue #, if available:*

*Description of changes:*
Python version need to be updated for TriggerCodeBuild CFT resource. The resource is failing and result CloudFormation fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
